### PR TITLE
Fix params to be keywords in save_pet_mad

### DIFF
--- a/src/pet_mad/_models.py
+++ b/src/pet_mad/_models.py
@@ -92,7 +92,7 @@ def save_pet_mad(*, version="latest", checkpoint_path=None, output=None):
         logging.info("putting TorchScript extensions in `extensions/`")
         extensions_directory = "extensions"
 
-    model = get_pet_mad(version, checkpoint_path)
+    model = get_pet_mad(version=version, checkpoint_path=checkpoint_path)
 
     if output is None:
         if checkpoint_path is None:


### PR DESCRIPTION
Currently `pet_mad.save_pet_mad` raises the following error:

```
from pet_mad import save_pet_mad

save_pet_mad(checkpoint_path="test.pt")


>> error:
{
	"name": "TypeError",
	"message": "get_pet_mad() takes 0 positional arguments but 2 were given",
	"stack": "---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[1], line 3
      1 from pet_mad import save_pet_mad
----> 3 save_pet_mad(checkpoint_path=\"test.pt\")

File /opt/miniconda3/envs/petmad-env/lib/python3.10/site-packages/pet_mad/_models.py:95, in save_pet_mad(version, checkpoint_path, output)
     92     logging.info(\"putting TorchScript extensions in `extensions/`\")
     93     extensions_directory = \"extensions\"
---> 95 model = get_pet_mad(version, checkpoint_path)
     97 if output is None:
     98     if checkpoint_path is None:

TypeError: get_pet_mad() takes 0 positional arguments but 2 were given"
}
```

=> this PR changes arguments of calling `get_pet_mad` to be keywords instead of positional arguments