### PR TITLE
Activated the non-conservative regime in the `PETMADCalculator`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ maintainers = [
 ]
 
 dependencies = [
-    "metatrain==2025.7",
+    "metatrain==2025.8.1",
     "huggingface_hub",
     "platformdirs",
     "tqdm",

--- a/src/pet_mad/calculator.py
+++ b/src/pet_mad/calculator.py
@@ -18,6 +18,7 @@ class PETMADCalculator(MetatomicCalculator):
         version: str = "latest",
         checkpoint_path: Optional[str] = None,
         *,
+        non_conservative=False,
         check_consistency=False,
         device=None,
     ):
@@ -26,6 +27,8 @@ class PETMADCalculator(MetatomicCalculator):
             "1.0.1", "1.0.0". Defaults to "latest".
         :param checkpoint_path: path to a checkpoint file to load the model from. If
             provided, the `version` parameter is ignored.
+        :param non_conservative: whether to use the non-conservative regime of forces and
+            stresses prediction. Defaults to False.
         :param check_consistency: should we check the model for consistency when
             running, defaults to False.
         :param device: torch device to use for the calculation. If `None`, we will try
@@ -56,6 +59,6 @@ class PETMADCalculator(MetatomicCalculator):
             extensions_directory=extensions_directory,
             check_consistency=check_consistency,
             device=device,
-            non_conservative=False,
+            non_conservative=non_conservative,
             additional_outputs={},
         )

--- a/tests/test_non_conservative.py
+++ b/tests/test_non_conservative.py
@@ -1,10 +1,19 @@
 from pet_mad.calculator import PETMADCalculator
 from ase.build import bulk
-import pytest
+import numpy as np
 
-@pytest.mark.skip(reason="Waiting until https://github.com/metatensor/metatensor/pull/914 is merged")
 def test_non_conservative():
     atoms = bulk("Si", cubic=True, a=5.43, crystalstructure="diamond")
-    atoms.calc = PETMADCalculator(version="latest", non_conservative=True)
-    _ = atoms.get_potential_energy()
-    _ = atoms.get_forces()
+    calc = PETMADCalculator(version="latest", non_conservative=False)
+    calc_nc = PETMADCalculator(version="latest", non_conservative=True)
+
+    atoms.calc = calc
+    forces = atoms.get_forces()
+    stresses = atoms.get_stress()
+
+    atoms.calc = calc_nc
+    forces_nc = atoms.get_forces()
+    stresses_nc = atoms.get_stress()
+
+    assert np.allclose(forces, forces_nc, atol=1e-1)
+    assert np.allclose(stresses, stresses_nc, atol=1e-1)


### PR DESCRIPTION
This PR activates the non-conservative (i.e. direct) forces and stresses predictions in the PET-MAD calculator, and adds a short documentation in the README.md on how to use it in simulations. 