### PR TITLE
Temporary pin petmad version to 1.0.1 inside featurizer

### DIFF
--- a/src/pet_mad/explore/_featurizer.py
+++ b/src/pet_mad/explore/_featurizer.py
@@ -106,7 +106,7 @@ class PETMADFeaturizer:
             cache_dir=cache_dir,
         )
 
-        petmad = get_pet_mad(version="latest", checkpoint_path=pet_checkpoint_path)
+        petmad = get_pet_mad(version="1.0.1", checkpoint_path=pet_checkpoint_path)
 
         explorer = MADExplorer(petmad.module, device=device)
         explorer.load_checkpoint(petmad_explorer_path)


### PR DESCRIPTION
Temporary fix to be able to use the featurizer having the latest checkpoint updated state which leads to the error:
```
File /opt/miniconda3/envs/petmad-env/lib/python3.10/site-packages/pet_mad/_models.py:72, in get_pet_mad(version, checkpoint_path)
     [67](https://file+.vscode-resource.vscode-cdn.net/opt/miniconda3/envs/petmad-env/lib/python3.10/site-packages/pet_mad/_models.py:67) with warnings.catch_warnings():
     [68](https://file+.vscode-resource.vscode-cdn.net/opt/miniconda3/envs/petmad-env/lib/python3.10/site-packages/pet_mad/_models.py:68)     warnings.filterwarnings(
     [69](https://file+.vscode-resource.vscode-cdn.net/opt/miniconda3/envs/petmad-env/lib/python3.10/site-packages/pet_mad/_models.py:69)         action="ignore",
...
    [182](https://file+.vscode-resource.vscode-cdn.net/opt/miniconda3/envs/petmad-env/lib/python3.10/site-packages/metatrain/utils/io.py:182)     )
    [183](https://file+.vscode-resource.vscode-cdn.net/opt/miniconda3/envs/petmad-env/lib/python3.10/site-packages/metatrain/utils/io.py:183) architecture = import_architecture(architecture_name)
    [185](https://file+.vscode-resource.vscode-cdn.net/opt/miniconda3/envs/petmad-env/lib/python3.10/site-packages/metatrain/utils/io.py:185) try:

ValueError: Checkpoint architecture 'llpr' not found in the available architectures. Available architectures are: ['experimental.nanopet', 'gap', 'pet', 'soap_bpnn', 'deprecated.pet']
```