### PR TITLE
Fix PET-MAD versions in HuggingFace URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ is installed as a dependency of PET-MAD. To evaluate the model, you first need
 to fetch the PET-MAD model from the HuggingFace repository:
 
 ```bash
-mtt export https://huggingface.co/lab-cosmo/pet-mad/resolve/main/models/pet-mad-latest.ckpt
+mtt export https://huggingface.co/lab-cosmo/pet-mad/resolve/v1.1.0/models/pet-mad-v1.1.0.ckpt
 ```
 
 Alternatively, you can also download the model from Python:
@@ -173,6 +173,7 @@ Alternatively, you can also download the model from Python:
 ```py
 import pet_mad
 
+# Saving the latest version of PET-MAD to a TorchScript file
 pet_mad.save_pet_mad(version="latest", output="pet-mad-latest.pt")
 
 # you can also get a metatomic AtomisticModel for advance usage
@@ -216,7 +217,7 @@ the installation instructions above). Then, follow the instructions
 Fetch the PET-MAD checkpoint from the HuggingFace repository:
 
 ```bash
-mtt export https://huggingface.co/lab-cosmo/pet-mad/resolve/v1.1.0/models/pet-mad-v1.1.0.ckpt
+mtt export https://huggingface.co/lab-cosmo/pet-mad/resolve/v1.1.0/models/pet-mad-v1.1.0.ckpt -o pet-mad-latest.pt
 ```
 
 This will download the model and convert it to TorchScript format compatible
@@ -234,7 +235,7 @@ atom_style atomic
 
 read_data silicon.data
 
-pair_style metatomic pet-mad-v1.1.0.pt device cpu # Change device to 'cuda' evaluate PET-MAD on GPU
+pair_style metatomic pet-mad-latest.pt device cpu # Change device to 'cuda' evaluate PET-MAD on GPU
 pair_coeff * * 14
 
 neighbor 2.0 bin
@@ -301,7 +302,7 @@ atom_style atomic/kk
 
 read_data silicon.data
 
-pair_style metatensor/kk pet-mad-v1.1.0.pt # This will use the same device as the kokkos simulation
+pair_style metatensor/kk pet-mad-latest.pt # This will use the same device as the kokkos simulation
 pair_coeff * * 14
 
 neighbor 2.0 bin

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ is installed as a dependency of PET-MAD. To evaluate the model, you first need
 to fetch the PET-MAD model from the HuggingFace repository:
 
 ```bash
-mtt export https://huggingface.co/lab-cosmo/pet-mad/resolve/v1.1.0/models/pet-mad-v1.1.0.ckpt
+mtt export https://huggingface.co/lab-cosmo/pet-mad/resolve/v1.1.0/models/pet-mad-v1.1.0.ckpt -o pet-mad-latest.pt
 ```
 
 Alternatively, you can also download the model from Python:


### PR DESCRIPTION
As in the description, some of the links to HF were not changed after a recent release