### PR TITLE
Add tests for metatrain dev version

### DIFF
--- a/.github/workflows/tests-dev.yml
+++ b/.github/workflows/tests-dev.yml
@@ -1,0 +1,40 @@
+name: Tests dev
+
+on:
+  schedule:
+    # check once a week on mondays
+    - cron: '0 10 * * 1'
+
+jobs:
+  tests-dev:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.13"]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install Zsh
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y zsh libfftw3-dev
+        touch ~/.zshrc
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install tests dependencies
+      run: python -m pip install tox
+
+    - name: run Python tests
+      run: |
+        tox -e tests-dev
+      env:
+        # Use the CPU only version of torch when building/running the code
+        PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu

--- a/tox.ini
+++ b/tox.ini
@@ -39,19 +39,28 @@ commands =
 
 [testenv:tests]
 description = Run basic package tests with pytest
-passenv = *
 deps =
     pytest
     pytest-cov
 
 changedir = tests
-allowlist_externals = bash
 commands =
     pytest \
         --cov={env_site_packages_dir}/pet_mad \
         --cov-append \
         --cov-report= \
         --import-mode=append \
+        --deselect=tests/test_basic_usage.py::test_version_deprecated \
+        {posargs}
+
+[testenv:tests-dev]
+description = Run basic package tests against metatrain dev version
+deps =
+    pytest
+changedir = tests
+commands =
+    pip install "metatrain @ git+https://github.com/metatensor/metatrain.git"
+    pytest \
         --deselect=tests/test_basic_usage.py::test_version_deprecated \
         {posargs}
 


### PR DESCRIPTION
Should be useful to track if we breaks here based on metatrain.

Currently, the tests are broken as because of wrong checkpoint version. Should be easy to fix.

```
FAILED test_basic_usage.py::test_get_pet_mad[1.1.0] - RuntimeError: Unable to load the model checkpoint for the 'pet' architecture: the checkpoint is using version 1, while the current version is 4; and trying to upgrade the checkpoint failed.
FAILED test_basic_usage.py::test_get_pet_mad[1.0.1] - RuntimeError: Unable to load the model checkpoint for the 'pet' architecture: the checkpoint is using version 1, while the current version is 4; and trying to upgrade the checkpoint failed.
FAILED test_basic_usage.py::test_save_pet_mad[1.1.0] - RuntimeError: Unable to load the model checkpoint for the 'pet' architecture: the checkpoint is using version 1, while the current version is 4; and trying to upgrade the checkpoint failed.
FAILED test_basic_usage.py::test_save_pet_mad[1.0.1] - RuntimeError: Unable to load the model checkpoint for the 'pet' architecture: the checkpoint is using version 1, while the current version is 4; and trying to upgrade the checkpoint failed.
FAILED test_basic_usage.py::test_basic_usage - RuntimeError: Unable to load the model checkpoint for the 'pet' architecture: the checkpoint is using version 1, while the current version is 4; and trying to upgrade the checkpoint failed.
FAILED test_basic_usage.py::test_version[1.1.0] - RuntimeError: Unable to load the model checkpoint for the 'pet' architecture: the checkpoint is using version 1, while the current version is 4; and trying to upgrade the checkpoint failed.
FAILED test_basic_usage.py::test_version[1.0.1] - RuntimeError: Unable to load the model checkpoint for the 'pet' architecture: the checkpoint is using version 1, while the current version is 4; and trying to upgrade the checkpoint failed.
FAILED test_md.py::test_basic_usage - RuntimeError: Unable to load the model checkpoint for the 'pet' architecture: the checkpoint is using version 1, while the current version is 4; and trying to upgrade the checkpoint failed.
FAILED test_non_conservative.py::test_non_conservative - RuntimeError: Unable to load the model checkpoint for the 'pet' architecture: the checkpoint is using version 1, while the current version is 4; and trying to upgrade the checkpoint failed.
```

We should fix the dev tests before we merge https://github.com/metatensor/metatrain/pull/724 and release metatrain 2025.9.