### PR TITLE
Add averaging over the Lebedev-Laikov grid

### DIFF
--- a/src/pet_mad/utils.py
+++ b/src/pet_mad/utils.py
@@ -1,11 +1,13 @@
 from metatomic.torch import ModelMetadata
 from ase import Atoms
 from ase.units import kB
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Dict
 import torch
 from pathlib import Path
 from urllib.parse import unquote
 from huggingface_hub import hf_hub_download
+from scipy.spatial.transform import Rotation
+import numpy as np
 import re
 
 
@@ -105,6 +107,29 @@ NUM_ELECTRONS_PER_ELEMENT = {
     "Cu": 11.0,
 }
 
+AVAILABLE_LEBEDEV_GRID_ORDERS = [3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 35, 41, 47,
+             53, 59, 65, 71, 77, 83, 89, 95, 101, 107, 113, 119, 125, 131]
+
+def rotate_atoms(atoms: Atoms, grid: np.ndarray) -> List[Atoms]:
+    rotated_atoms_list = []
+    for rot_vec in grid:
+        new_atoms = atoms.copy()
+        new_atoms.rotate([1,0,0], rot_vec, rotate_cell=True)
+        rotated_atoms_list.append(new_atoms)
+    return rotated_atoms_list
+
+def compute_rotational_average(results: Dict[str, np.ndarray], grid: np.ndarray) -> Dict[str, np.ndarray]:
+    new_results = {}
+    rotations = [Rotation.align_vectors(rot_vector, [1,0,0])[0].inv() for rot_vector in grid]
+    for key, value in results.items():
+        if "energy" in key:
+            new_results[key] = np.mean(value)
+            new_results[key + "_std"] = np.std(value)
+        else:
+            rotated_back_values = np.array([rot.apply(val) for rot, val in zip(rotations, value)])
+            new_results[key] = rotated_back_values.mean(axis=0)
+            new_results[key + "_std"] = rotated_back_values.std(axis=0)
+    return new_results
 
 def get_pet_mad_metadata(version: str):
     return ModelMetadata(


### PR DESCRIPTION
This PR adds a rotational averaging functionality for PET-MAD. By design, PET-MAD is not rotationally equivariant, which can lead to minor deviations in predictions upon rotating the structure. In order to get accurate results (especially while running the symmetry-sensitive calculations like phonons), it might be crucial to average the predictions over a set of rotations, that uniformly cover the unit sphere.

Rotational averaging can be activated by

```python
from pet_mad.calculator import PETMADCalculator

calc = PETMADCalculator(rot_average_order=order)
```
where `order` value corresponds to the order of the Lebedev-Laikov grid.

When rotational averaging is activated, energies, forces and stress evaluations can be done normally by calling

```python
atoms.calc = calc
atoms.get_potential_energy()
atoms.get_forces()
atoms.get_stress()
```

but they will be implicitly averaged over a selected grid of rotations. Results on standard deviations in predictions can be found in the `calc.results`:

```python
calc.results['energy_rot_std']
calc.results['forces_rot_std']
```
