### PR TITLE
Make `save_pet_mad` public again

### DIFF
--- a/src/pet_mad/__init__.py
+++ b/src/pet_mad/__init__.py
@@ -1,4 +1,6 @@
-from ._models import get_pet_mad, save_pet_mad  # noqa: F401
+from ._models import get_pet_mad, save_pet_mad
 
 
 __version__ = "1.4.4"
+
+__all__ = ["get_pet_mad", "save_pet_mad"]

--- a/src/pet_mad/_models.py
+++ b/src/pet_mad/_models.py
@@ -89,7 +89,7 @@ def save_pet_mad(*, version: str = "latest", checkpoint_path=None, output=None):
 
     if output is None:
         if checkpoint_path is None:
-            output = f"pet-mad-{version}.pt"
+            output = f"pet-mad-v{version}.pt"
         else:
             raise
 


### PR DESCRIPTION
This was removed in https://github.com/lab-cosmo/pet-mad/commit/02236c1277e9e6ab4c0c920bf2279ae9158173f5, resulting in the instructions in the README being wrong.

Linked to https://github.com/lab-cosmo/atomistic-cookbook/issues/208