### PR TITLE
Add workaround for Pytorch bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,6 @@ Additional documentation can be found in the
 - If you hit a weird bug when running more than 65535 atoms on GPU, this is not an out-of-memory bug, but a
   pytorch bug. You can fix it by adding `torch.backends.cuda.enable_mem_efficient_sdp(False)`
   (after importing torch) near the top of your file.
-  top of your file.
 
 **The model is not fully equivariant. Should I worry?**
 


### PR DESCRIPTION
Currently, any force evaluation with more than 65535 atoms fails with this error
```
    return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: The size of tensor a (70304) must match the size of tensor b (65535) at non-singleton dimension 0
```