### PR TITLE
Update nvalchemi-toolkit-ops dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ maintainers = [
 dependencies = [
     "metatrain>=2026.2,<2026.3",
     "metatomic-ase",
-    "nvalchemi-toolkit-ops==0.2.0",
+    "nvalchemi-toolkit-ops==0.3.0",
     "huggingface_hub",
     "hf_xet",
     "packaging",


### PR DESCRIPTION
Metatomic-ase (which we now depend on) only accepts >=0.3.0, so it would make sense to pin it to 0.3.0 here