### PR TITLE
add model parameters and uncertainty info

### DIFF
--- a/docs/src/models.rst
+++ b/docs/src/models.rst
@@ -50,6 +50,122 @@ Recommended usage:
 - **PET-SPICE** for accurate and fast simulations of molecules and
   biomolecules.
 
+Model sizes
+-----------
+
+The XS / S / M / L / XL suffixes correspond to a fixed family of
+architecture hyperparameters, introduced as the PET-OMat Pareto front in
+`Bigi et al., 2026 <https://arxiv.org/abs/2601.16195>`_ (Table IV,
+Appendix A). The same naming convention is reused for the other UPET
+families (PET-MAD, PET-OMAD, PET-OMATPES, PET-SPICE), so that e.g.
+PET-MAD-S and PET-OMat-S share the same architectural budget.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 12 12 12 12 12
+
+   * - Hyperparameter
+     - XS
+     - S
+     - M
+     - L
+     - XL
+   * - Parameter count
+     - 4.5 M
+     - 25.9 M
+     - 109 M
+     - 255 M
+     - 730 M
+   * - Edge feature dimension
+     - 128
+     - 256
+     - 384
+     - 512
+     - 640
+   * - GNN layers
+     - 2
+     - 3
+     - 3
+     - 4
+     - 5
+   * - Transformer (attention) layers
+     - 1
+     - 1
+     - 2
+     - 2
+     - 3
+   * - Graph cutoff radius (Å)
+     - 7.5
+     - 8.0
+     - 8.5
+     - 9.0
+     - 10.0
+   * - Adaptive neighbor number
+     - 8
+     - 16
+     - 24
+     - 32
+     - 40
+
+Larger sizes are more accurate but also more expensive and have a lower
+maximum system size before running out of GPU memory — see Fig. A2 in the
+reference above for the accuracy / cost / memory Pareto plot. As a rule of
+thumb, **S** is a good default for molecular dynamics, while **L** / **XL**
+are preferred for materials discovery workflows where accuracy dominates
+cost.
+
+Uncertainty quantification
+--------------------------
+
+A subset of PET-MAD checkpoints expose per-structure energy uncertainty
+estimates through :py:meth:`~upet.calculator.UPETCalculator.get_energy_uncertainty`
+and :py:meth:`~upet.calculator.UPETCalculator.get_energy_ensemble`
+(LLPR + shallow-ensemble heads, see :ref:`ase-uncertainty` for usage):
+
+- ``pet-mad-s`` v1.0.2
+- ``pet-mad-xs`` v1.5.0
+- ``pet-mad-s`` v1.5.0
+
+Calling these methods on other checkpoints will raise an error.
+
+Non-conservative forces
+-----------------------
+
+All UPET checkpoints support conservative forces (the derivative of the
+predicted energy). Most also expose a direct, non-conservative force head
+that is 2–3× faster at inference; see :ref:`ase-non-conservative`. The
+following checkpoints are conservative-only and therefore do **not**
+support ``non_conservative=True``:
+
+- ``pet-mad-s`` v1.0.2
+- ``pet-spice-s`` v0.2.0
+- ``pet-spice-l`` v0.2.0
+
+PET-MAD-DOS
+-----------
+
+In addition to the energy/force models above, UPET ships **PET-MAD-DOS**,
+a separate model family for predicting the electronic density of states,
+Fermi levels and bandgaps via
+:py:class:`~upet.calculator.PETMADDOSCalculator` (see
+:ref:`ase-pet-mad-dos`).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 30 30
+
+   * - Version
+     - Level of theory
+     - Supported outputs
+     - Notes
+   * - 1.0
+     - PBE (Materials Project)
+     - DOS, Fermi level, bandgap
+     - Latest stable
+
+See `How et al., 2025 <https://arxiv.org/abs/2508.17418>`_ for the
+methodology.
+
 Legacy models
 -------------
 

--- a/docs/src/usage/ase.rst
+++ b/docs/src/usage/ase.rst
@@ -89,6 +89,8 @@ checkpoints or reproducibility):
    calculator = UPETCalculator(checkpoint_path="pet-mad-s-v1.5.0.ckpt", device="cpu")
 
 
+.. _ase-non-conservative:
+
 Non-conservative (direct) forces and stresses
 ---------------------------------------------
 
@@ -123,6 +125,8 @@ More details on making direct-force MD simulations reliable are in the
 <https://atomistic-cookbook.org/examples/pet-mad-nc/pet-mad-nc.html>`_.
 
 
+.. _ase-uncertainty:
+
 Uncertainty quantification
 --------------------------
 
@@ -131,6 +135,12 @@ This is important when probing the model on data that may be substantially
 different from its training distribution, or when propagating uncertainty
 to derived observables (phase transition temperatures, diffusion
 coefficients, and so on).
+
+.. note::
+
+   Uncertainty quantification is only available for a subset of
+   checkpoints (currently ``pet-mad-s`` v1.0.2, ``pet-mad-xs`` v1.5.0
+   and ``pet-mad-s`` v1.5.0). See :ref:`models` for the full list.
 
 Use the ``get_energy_uncertainty`` and ``get_energy_ensemble`` methods of
 :py:class:`~upet.calculator.UPETCalculator`:
@@ -241,6 +251,8 @@ Then combine both calculators with ``ase.calculators.mixing.SumCalculator``:
    combined_calc = SumCalculator([calc_upet, dft_d3])
    atoms.calc = combined_calc
 
+
+.. _ase-pet-mad-dos:
 
 DOS, Fermi levels and bandgaps (PET-MAD-DOS)
 --------------------------------------------


### PR DESCRIPTION
We add model parameters and info on uncertainty
one note all these kind of references seem to be broken [:py:class:`~upet.calculator.UPETCalculator`](https://github.com/lab-cosmo/upet/blob/f959047c66509d78ec88b2b0e2415dabcb2d96a7/docs/src/quickstart.rst#id1):